### PR TITLE
Assign user role setting to default if null

### DIFF
--- a/views/list-add-edit.inc.php
+++ b/views/list-add-edit.inc.php
@@ -52,8 +52,11 @@
 							$ua = 0;
 							
 							// Import empty roles fix
-							if(empty($users)) $users = $this->settings['user_role'];
-							
+							if(empty($users)){
+								$this->settings['user_role'] = array( 'administrator', 'editor' );
+								$users = $this->settings['user_role'];
+							}
+
 							foreach($users as $user){
 								if($ua>0) $usersAllowed .= ', ';
 								/*if(in_array($user, $registered_usr) > -1)*/ $usersAllowed .= __( $registered_usr[$user]['name'], $this->slug );


### PR DESCRIPTION
I saw your Import empty roles fix. 
But I guess when import "restricted":null, it also assign null to $user at line 48?
I tried to get the default user role setting at line 115 in client-documentation.php, but not really familiar with php :( so hard coded it.

I guess you properly have  a better idea on fixing it :)